### PR TITLE
Add `firewalld_service` resource

### DIFF
--- a/lib/itamae/plugin/resource/firewalld.rb
+++ b/lib/itamae/plugin/resource/firewalld.rb
@@ -1,4 +1,5 @@
 require 'itamae/plugin/resource/firewalld/version'
+require 'itamae/plugin/resource/firewalld_service'
 require 'itamae/plugin/resource/firewalld_zone'
 
 module Itamae

--- a/lib/itamae/plugin/resource/firewalld_service.rb
+++ b/lib/itamae/plugin/resource/firewalld_service.rb
@@ -1,0 +1,141 @@
+require 'itamae/resource/base'
+require 'rexml/document'
+
+module Itamae
+  module Plugin
+    module Resource
+      class FirewalldService < ::Itamae::Resource::Base
+
+        define_attribute :action, default: :create
+        define_attribute :name, type: String, default_name: true
+
+        define_attribute :short,       type: String, default: ''
+        define_attribute :description, type: String, default: ''
+        define_attribute :protocol,    type: String, default: ''
+        define_attribute :port,        type: String, default: ''
+        define_attribute :module_name, type: String, default: ''
+        define_attribute :to_ipv4,     type: String, default: ''
+        define_attribute :to_ipv6,     type: String, default: ''
+
+        def pre_action
+          current.status = current_status
+
+          return if (@current_action != :create) || (current.status == :undefined)
+
+          xml = run_specinfra(:get_file_content, service_xmlfile_path).stdout
+          return if xml.empty?
+
+          service = REXML::Document.new(xml).elements['/service'].elements
+
+          if service['short']
+            current.short = service['short'].text
+          end
+
+          if service['description']
+            current.description = service['description'].text
+          end
+
+          if service['port']
+            current.protocol = service['port'].attributes['protocol']
+            current.port = service['port'].attributes['port']
+          end
+
+          if service['module']
+            current.module_name = service['module'].attributes['name']
+          end
+
+          if service['destination']
+            current.to_ipv4 = service['destination'].attributes['ipv4']
+            current.to_ipv6 = service['destination'].attributes['ipv6']
+          end
+        end
+
+        def action_create(options)
+          run_specinfra(:move_file, build_xmlfile_on_remote, service_xmlfile_path)
+          attributes.status = :defined
+        end
+
+        def action_delete(options)
+          return if current.status == :undefined
+
+          run_command(['firewall-cmd', '--permanent', '--delete-service', attributes.name])
+          attributes.status = :undefined
+        end
+
+        private
+
+        def build_xmlfile_on_remote
+          local_path  = build_xmlfile_on_local
+          remote_path = ::File.join(runner.tmpdir, Time.now.to_f.to_s)
+
+          send_file(local_path, remote_path)
+          remote_path
+        end
+
+        def build_xmlfile_on_local
+          root_document  = ::REXML::Document.new
+          root_document << ::REXML::XMLDecl.new('1.0', 'utf-8')
+          @service_document = root_document.add_element('service')
+
+          add_short_tag
+          add_description_tag
+          add_port_tag
+          add_module_tag
+          add_destination_tag
+
+          f = Tempfile.open('itamae_firewalld_service')
+          root_document.write(f)
+          f.close
+          f.path
+        end
+
+        def add_short_tag
+          return if attributes.short.empty?
+
+          short = @service_document.add_element('short')
+          short.text = attributes.short unless attributes.short.empty?
+        end
+
+        def add_description_tag
+          return if attributes.description.empty?
+
+          description = @service_document.add_element('description')
+          description.text = attributes.description unless attributes.description.empty?
+        end
+
+        def add_port_tag
+          return if (attributes.protocol.empty? && attributes.port.empty?)
+
+          node = @service_document.add_element('port')
+          node.add_attribute('protocol', attributes.protocol) unless attributes.protocol.empty?
+          node.add_attribute('port', attributes.port) unless attributes.port.empty?
+        end
+
+        def add_module_tag
+          return if attributes.module_name.empty?
+
+          node = @service_document.add_element('module')
+          node.add_attribute('name', attributes.module_name) unless attributes.module_name.empty?
+        end
+
+        def add_destination_tag
+          return if (attributes.to_ipv4.empty? && attributes.to_ipv6.empty?)
+
+          node = @service_document.add_element('destination')
+          node.add_attribute('ipv4', attributes.to_ipv4) unless attributes.to_ipv4.empty?
+          node.add_attribute('ipv6', attributes.to_ipv6) unless attributes.to_ipv6.empty?
+        end
+
+        def service_xmlfile_path
+          "/etc/firewalld/services/#{attributes.name}.xml"
+        end
+
+        def current_status
+          command  = ['firewall-cmd', '--permanent', '--list-services']
+          services = run_command(command).stdout.strip.split
+          services.include?(attributes.name) ? :defined : :undefined
+        end
+      end
+    end
+  end
+end

--- a/test/itamae/plugin/resource/test_firewalld_service.rb
+++ b/test/itamae/plugin/resource/test_firewalld_service.rb
@@ -1,0 +1,121 @@
+require 'helper'
+require 'itamae/plugin/resource/firewalld_service'
+
+module Itamae
+  module Plugin
+    module Resource
+      # Stub
+      class FirewalldService
+        def send_file(from, to)
+          @local_path = from
+        end
+
+        def local_path
+          @local_path
+        end
+      end
+
+      class TestFirewalldService < Test::Unit::TestCase
+        setup do
+          @resource = FirewalldService.new(stub, 'test-service')
+        end
+
+        sub_test_case '#action_delete' do
+          setup do
+            @resource.attributes.action = :delete
+          end
+
+          sub_test_case 'predefined service' do
+            setup do
+              @resource.expects(:run_command)
+                .with(['firewall-cmd', '--permanent', '--list-services'])
+                .returns(stub(stdout: 'service1 service2 test-service'))
+            end
+
+            test 'delete service' do
+              @resource.expects(:run_command).with(['firewall-cmd', '--permanent', '--delete-service', 'test-service'])
+              @resource.expects(:notify)
+              @resource.run
+            end
+          end
+
+          sub_test_case 'undefined service' do
+            setup do
+              @resource.expects(:run_command)
+                .with(['firewall-cmd', '--permanent', '--list-services'])
+                .returns(stub(stdout: 'service1 service2'))
+            end
+
+            test 'delete service (noop)' do
+              @resource.expects(:notify).never
+              @resource.run
+            end
+          end
+        end
+
+        sub_test_case '#action_create' do
+          setup do
+            @resource.attributes.action = :create
+            @resource.stubs(:runner).returns(stub(tmpdir: ::Dir.tmpdir))
+            @resource.stubs(:move_file)
+            @resource.stubs(:run_specinfra).with(:move_file, is_a(String), is_a(String))
+
+            @resource.expects(:notify)
+          end
+
+          sub_test_case 'undefined service' do
+            setup do
+              @resource.stubs(:current_status).returns(:undefined)
+            end
+
+            test 'create service' do
+              @resource.run
+
+              assert ::File.exists?(@resource.local_path )
+            end
+          end
+
+          sub_test_case 'predefined service' do
+            setup do
+              @resource.stubs(:current_status).returns(:defined)
+              @resource.stubs(:run_specinfra)
+                .with(:get_file_content, '/etc/firewalld/services/test-service.xml')
+                .returns(stub(stdout: <<-EOS))
+<?xml version="1.0" encoding="utf-8"?>
+<service>
+  <short>test-service</short>
+  <description>test-service description</description>
+  <port protocol="tcp" port="2222"/>
+  <module name="test-module"/>
+  <destination ipv4="224.0.0.251" ipv6="ff02::fb"/>
+</service>
+                 EOS
+            end
+
+            test 'update service' do
+              @resource.attributes.short       = 'test-service!!'
+              @resource.attributes.description = 'test-service update description'
+              @resource.attributes.protocol    = 'udp'
+              @resource.attributes.port        = '2222-2224'
+              @resource.attributes.module_name = 'new-test-module'
+              @resource.attributes.to_ipv4     = '172.17.0.1'
+              @resource.attributes.to_ipv6     = 'ffff::fc'
+              @resource.run
+
+              root = REXML::Document.new(File.read(@resource.local_path))
+              service = root.elements['/service'].elements
+
+              assert_equal @resource.attributes.short,       service['short'].text
+              assert_equal @resource.attributes.description, service['description'].text
+              assert_equal @resource.attributes.protocol,    service['port'].attributes['protocol']
+              assert_equal @resource.attributes.port,        service['port'].attributes['port']
+              assert_equal @resource.attributes.module_name, service['module'].attributes['name']
+              assert_equal @resource.attributes.to_ipv4,     service['destination'].attributes['ipv4']
+              assert_equal @resource.attributes.to_ipv6,     service['destination'].attributes['ipv6']
+            end
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Provides a `firewalld_service` resource that can create or delete of `Service`.

``` ruby
firewalld_service 'my-service' do
  short       'My Service'
  description 'description'
  port        '137'
  protocol    'tcp'
  module_name 'nf_conntrack_netbios_ns'
  to_ipv4     '224.0.0.251'
  to_ipv6     'ff02::fb'

  notifies :restart, 'service[firewalld]'
end
```

After `itamae` execute, `/etc/firewalld/service/my-service.xml` is created:

``` xml
<?xml version='1.0' encoding='UTF-8'?>
<service>
  <short>My Service</short>
  <description>description</description>
  <port port='137' protocol='tcp'/>
  <module name='nf_conntrack_netbios_ns'/>
  <destination ipv4='224.0.0.251' ipv6='ff02::fb'/>
</service>
```
