### PR TITLE
Allow multiple ports per service definition

### DIFF
--- a/lib/itamae/plugin/resource/firewalld_service.rb
+++ b/lib/itamae/plugin/resource/firewalld_service.rb
@@ -35,7 +35,11 @@ module Itamae
           end
 
           current.ports = service.collect('port') do |port|
-            [port.attributes['protocol'], port.attributes['port']]
+            if port.attributes['port'].nil? || port.attributes['port'].empty?
+              port.attributes['protocol']
+            else
+              "#{port.attributes['port']}/#{port.attributes['protocol']}"
+            end
           end
 
           if service['module']

--- a/lib/itamae/plugin/resource/firewalld_service.rb
+++ b/lib/itamae/plugin/resource/firewalld_service.rb
@@ -11,8 +11,7 @@ module Itamae
 
         define_attribute :short,       type: String, default: ''
         define_attribute :description, type: String, default: ''
-        define_attribute :protocol,    type: String, default: ''
-        define_attribute :port,        type: String, default: ''
+        define_attribute :ports,       type: Array,  default: []
         define_attribute :module_name, type: String, default: ''
         define_attribute :to_ipv4,     type: String, default: ''
         define_attribute :to_ipv6,     type: String, default: ''
@@ -35,10 +34,9 @@ module Itamae
             current.description = service['description'].text
           end
 
-          if service['port']
-            current.protocol = service['port'].attributes['protocol']
-            current.port = service['port'].attributes['port']
-          end
+          current.ports = service.collect('port') {|port|
+            [port.attributes['protocol'], port.attributes['port']]
+          }
 
           if service['module']
             current.module_name = service['module'].attributes['name']
@@ -48,6 +46,12 @@ module Itamae
             current.to_ipv4 = service['destination'].attributes['ipv4']
             current.to_ipv6 = service['destination'].attributes['ipv6']
           end
+        end
+
+        def show_differences
+          current.ports = normalize_ports(current.ports)
+          attributes.ports = normalize_ports(attributes.ports)
+          super
         end
 
         def action_create(options)
@@ -64,6 +68,19 @@ module Itamae
 
         private
 
+        def normalize_ports(ports)
+          return [] if ports.nil?
+          ports.collect {|port|
+            protocol, portnum = port
+            if portnum
+              portnum = "#{portnum.min}-#{portnum.max}" if portnum.is_a?(Range)
+              [protocol.to_s, portnum.to_s]
+            else
+              [protocol.to_s, '']
+            end
+          }.sort
+        end
+
         def build_xmlfile_on_remote
           local_path  = build_xmlfile_on_local
           remote_path = ::File.join(runner.tmpdir, Time.now.to_f.to_s)
@@ -79,7 +96,7 @@ module Itamae
 
           add_short_tag
           add_description_tag
-          add_port_tag
+          add_port_tags
           add_module_tag
           add_destination_tag
 
@@ -103,12 +120,16 @@ module Itamae
           description.text = attributes.description unless attributes.description.empty?
         end
 
-        def add_port_tag
-          return if (attributes.protocol.empty? && attributes.port.empty?)
+        def add_port_tags
+          return unless attributes.ports
 
-          node = @service_document.add_element('port')
-          node.add_attribute('protocol', attributes.protocol) unless attributes.protocol.empty?
-          node.add_attribute('port', attributes.port) unless attributes.port.empty?
+          normalize_ports(attributes.ports).each do |port|
+            protocol, portnum = port
+
+            node = @service_document.add_element('port')
+            node.add_attribute('protocol', protocol.to_s)
+            node.add_attribute('port', portnum.to_s)
+          end
         end
 
         def add_module_tag

--- a/test/itamae/plugin/resource/test_firewalld_service.rb
+++ b/test/itamae/plugin/resource/test_firewalld_service.rb
@@ -86,6 +86,8 @@ module Itamae
   <short>test-service</short>
   <description>test-service description</description>
   <port protocol="tcp" port="2222"/>
+  <port protocol="udp" />
+  <port protocol="tcp" port="80-82"/>
   <module name="test-module"/>
   <destination ipv4="224.0.0.251" ipv6="ff02::fb"/>
 </service>
@@ -100,6 +102,13 @@ module Itamae
               @resource.attributes.to_ipv4     = '172.17.0.1'
               @resource.attributes.to_ipv6     = 'ffff::fc'
               @resource.run
+
+              assert_equal 'test-service',                   @resource.current.short
+              assert_equal 'test-service description',       @resource.current.description
+              assert_equal ['2222/tcp', '80-82/tcp', 'udp'], @resource.current.ports
+              assert_equal 'test-module',                    @resource.current.module_name
+              assert_equal '224.0.0.251',                    @resource.current.to_ipv4
+              assert_equal 'ff02::fb',                       @resource.current.to_ipv6
 
               root = REXML::Document.new(File.read(@resource.local_path))
               service = root.elements['/service'].elements

--- a/test/itamae/plugin/resource/test_firewalld_service.rb
+++ b/test/itamae/plugin/resource/test_firewalld_service.rb
@@ -95,7 +95,7 @@ module Itamae
             test 'update service' do
               @resource.attributes.short       = 'test-service!!'
               @resource.attributes.description = 'test-service update description'
-              @resource.attributes.ports       = [['udp', '2222-2224']]
+              @resource.attributes.ports       = ['2222-2224/udp', '80/tcp', 'igmp']
               @resource.attributes.module_name = 'new-test-module'
               @resource.attributes.to_ipv4     = '172.17.0.1'
               @resource.attributes.to_ipv6     = 'ffff::fc'
@@ -106,8 +106,12 @@ module Itamae
 
               assert_equal @resource.attributes.short,       service['short'].text
               assert_equal @resource.attributes.description, service['description'].text
-              assert_equal @resource.attributes.ports[0][0], service['port'].attributes['protocol']
-              assert_equal @resource.attributes.ports[0][1], service['port'].attributes['port']
+              assert_equal 'udp',                            service[1, 'port'].attributes['protocol']
+              assert_equal '2222-2224',                      service[1, 'port'].attributes['port']
+              assert_equal 'tcp',                            service[2, 'port'].attributes['protocol']
+              assert_equal '80',                             service[2, 'port'].attributes['port']
+              assert_equal 'igmp',                           service[3, 'port'].attributes['protocol']
+              assert_equal '',                               service[3, 'port'].attributes['port']
               assert_equal @resource.attributes.module_name, service['module'].attributes['name']
               assert_equal @resource.attributes.to_ipv4,     service['destination'].attributes['ipv4']
               assert_equal @resource.attributes.to_ipv6,     service['destination'].attributes['ipv6']

--- a/test/itamae/plugin/resource/test_firewalld_service.rb
+++ b/test/itamae/plugin/resource/test_firewalld_service.rb
@@ -95,8 +95,7 @@ module Itamae
             test 'update service' do
               @resource.attributes.short       = 'test-service!!'
               @resource.attributes.description = 'test-service update description'
-              @resource.attributes.protocol    = 'udp'
-              @resource.attributes.port        = '2222-2224'
+              @resource.attributes.ports       = [['udp', '2222-2224']]
               @resource.attributes.module_name = 'new-test-module'
               @resource.attributes.to_ipv4     = '172.17.0.1'
               @resource.attributes.to_ipv6     = 'ffff::fc'
@@ -107,8 +106,8 @@ module Itamae
 
               assert_equal @resource.attributes.short,       service['short'].text
               assert_equal @resource.attributes.description, service['description'].text
-              assert_equal @resource.attributes.protocol,    service['port'].attributes['protocol']
-              assert_equal @resource.attributes.port,        service['port'].attributes['port']
+              assert_equal @resource.attributes.ports[0][0], service['port'].attributes['protocol']
+              assert_equal @resource.attributes.ports[0][1], service['port'].attributes['port']
               assert_equal @resource.attributes.module_name, service['module'].attributes['name']
               assert_equal @resource.attributes.to_ipv4,     service['destination'].attributes['ipv4']
               assert_equal @resource.attributes.to_ipv6,     service['destination'].attributes['ipv6']


### PR DESCRIPTION
According to firewalld.service(5), a service definition can have more than
one `<port>`s in its XML configuration file.

In order to handle such a service configuration with the `firewalld_service`
resource, this patch replaces its `protocol` and `port` attributes by `ports`
attribute, which takes an array of pairs of a protocol and a port number.

For example, this patch allows the following resource definition:

```
firewalld_service 'dns' do
  ports [[:tcp, 53], [:udp, 53]]
end
```