### PR TITLE
`--list-servies` print predefined services **for a zone**

### DIFF
--- a/lib/itamae/plugin/resource/firewalld_service.rb
+++ b/lib/itamae/plugin/resource/firewalld_service.rb
@@ -153,7 +153,7 @@ module Itamae
         end
 
         def current_status
-          command  = ['firewall-cmd', '--permanent', '--list-services']
+          command  = ['firewall-cmd', '--permanent', '--get-services']
           services = run_command(command).stdout.strip.split
           services.include?(attributes.name) ? :defined : :undefined
         end

--- a/test/itamae/plugin/resource/test_firewalld_service.rb
+++ b/test/itamae/plugin/resource/test_firewalld_service.rb
@@ -20,7 +20,7 @@ module Itamae
           sub_test_case 'predefined service' do
             setup do
               @resource.expects(:run_command)
-                .with(['firewall-cmd', '--permanent', '--list-services'])
+                .with(['firewall-cmd', '--permanent', '--get-services'])
                 .returns(stub(stdout: 'service1 service2 test-service'))
             end
 
@@ -34,7 +34,7 @@ module Itamae
           sub_test_case 'undefined service' do
             setup do
               @resource.expects(:run_command)
-                .with(['firewall-cmd', '--permanent', '--list-services'])
+                .with(['firewall-cmd', '--permanent', '--get-services'])
                 .returns(stub(stdout: 'service1 service2'))
             end
 


### PR DESCRIPTION
`man firewall-cmd` display:

```
       [--permanent] --get-services
           Print predefined services as a space separated list.

       [--permanent] [--zone=zone] --list-services
           List services added for zone as a space separated list. If zone is
           omitted, default zone will be used.
```

I had misunderstood :bow: 